### PR TITLE
Fix argument name low->high and match np.randint behaviour with high inclusive

### DIFF
--- a/src/main/scala/botkop/numsca/package.scala
+++ b/src/main/scala/botkop/numsca/package.scala
@@ -63,11 +63,11 @@ package object numsca {
   def rand(shape: Array[Int]): Tensor = new Tensor(Nd4j.rand(shape.toArray))
   def rand(shape: Int*): Tensor = rand(shape.toArray)
 
-  def randint(low: Int, shape: Array[Int]): Tensor = {
-    val data = Array.fill(shape.product)(Random.nextInt(low).toDouble)
+  def randint(high: Int, shape: Array[Int]): Tensor = {
+    val data = Array.fill(shape.product)(Random.nextInt(high + 1).toDouble)
     Tensor(data).reshape(shape)
   }
-  def randint(low: Int, shape: Int*): Tensor = randint(low, shape.toArray)
+  def randint(high: Int, shape: Int*): Tensor = randint(high, shape.toArray)
 
   def uniform(low: Double = 0.0,
               high: Double = 1.0,


### PR DESCRIPTION
Hi,

1) In method `ns.randint` argument named 'low' is actually 'high'. Renaming it to reflect correct behaviour.
2) in numpy 'high' argument is inclusive. To mimic that I changed rolling to Random.randInt(high+1), because java Random.randInt is exclusive.